### PR TITLE
WIP *DO NOT MERGE*: new-scriopt/httpcrtsrv

### DIFF
--- a/non-wheel/httpcrtsrv/httpsrv.py
+++ b/non-wheel/httpcrtsrv/httpsrv.py
@@ -70,7 +70,7 @@ MaxDynamicServers 100
 ;V5R4: SI43221
 ;V6R1: SI43224
 ;V7R1: SI43222
-    
+
 ''' % name
 
 def get_fastcgi_http_add_conf(name):


### PR DESCRIPTION
This is a WIP, please do not merge until it is complete. Right now, this SQL has no effect when ran via Python:

```sql
create or replace alias QUSRSYS.QATMHINSTC_test for QUSRSYS.QATMHINSTC(test);
update QUSRSYS.QATMHINSTC_test
set CHARFIELD = '-apache -d /www/test -f conf/httpd.conf -AutoStartN';
```

When run outside of Python, it works and the correct `httpd.conf` is pointed to.

I would prefer to use the `QzuiCreateInstance` API, but I would need help using the Python Toolkit. Any suggestions @kadler?
  